### PR TITLE
fix standalone docker name

### DIFF
--- a/docker/standalone/README.md
+++ b/docker/standalone/README.md
@@ -3,17 +3,17 @@
 Build with
 
 ```shell
-docker build --rm -t lcdm/standalone-info490 .
+docker build --rm -t lcdm/standalone-rppdss .
 ```
 
 or simply pull
 
 ```shell
-docker pull lcdm/standalone-info490
+docker pull lcdm/standalone-rppdss
 ```
 
 To run a Jupyter notebook server, run
 
 ```shell
-docker run -d -p 8888:8888 --name standalone lcdm/standalone-info490
+docker run -d -p 8888:8888 --name standalone lcdm/standalone-rppdss
 ```


### PR DESCRIPTION
Change `standalone-info490` to `standalone-rppdss`.
