### PR TITLE
traceroute and dig

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && \
     apt-get install -y -q \
     vim \
     wget \
+    traceroute \
+    dnsutils \
     # fonts needed in seaborn 
     ttf-liberation \ 
     ttf-bitstream-vera \

--- a/notebooks/1_Breakout.ipynb
+++ b/notebooks/1_Breakout.ipynb
@@ -107,7 +107,7 @@
     "\n",
     "### Use the traceroute command:\n",
     "\n",
-    "At the Unix shell (not in a Docker container) try out the `traceroute`\n",
+    "At the Unix shell, try out the `traceroute`\n",
     "command.\n",
     "\n",
     "```\n",


### PR DESCRIPTION
Install `traceroute` and `dnsutils` (for `dig`). Since this enables the `traceroute` command in containers, this PR also removes the line `(not in a Docker container)` in `1_Breakout.ipynb`.
